### PR TITLE
fix(docker): change mongo storage to a volume instead of local dir

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     image: mongo
     restart: always
     volumes:
-      - ./services/mongo/.dbdata/.mongo-data:/data/db
+      - mongo-data-volume:/data/db
     ports:
       - '27017:27017'
     environment:
@@ -96,6 +96,7 @@ volumes:
   eosio-data-volume:
   keosd-data-volume:
     external: true # set false to delete wallet
+  mongo-data-volume:
 
 networks:
   eoslocal:

--- a/scripts/flush.sh
+++ b/scripts/flush.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 echo "Flushing all blockchain and databases data"
-docker-compose down -v && rm -rf ./services/mongo/.dbdata
+docker-compose down -v


### PR DESCRIPTION
Docker-for-windows doesn't play nicely with external local storage for mongodb. The solution, for now, is to use an explicit docker volume. This isn't necessary for other environments, but it does help bring in another to the project (Windows).