### PR TITLE
fix(docker): add http-validate-host=false to config.ini

### DIFF
--- a/services/eosio/config/config.ini
+++ b/services/eosio/config/config.ini
@@ -4,6 +4,8 @@ http-alias=127.0.0.1:8888
 http-alias=eosio:8888
 http-alias=localhost:8888
 http-alias=eosio.eoslocal.io
+http-validate-host=false
+
 access-control-allow-origin = *
 # Enable production on a stale chain, since a single-node test chain is pretty much always stale
 enable-stale-production = true


### PR DESCRIPTION
Adding http-validate-host=false to config.ini allows for the nginx reverse proxy to resolve