### PR TITLE
fix(docker): update config.ini for more generalized development

### DIFF
--- a/services/eosio/config/config.ini
+++ b/services/eosio/config/config.ini
@@ -2,6 +2,8 @@
 http-server-address = 0.0.0.0:8888
 http-validate-host=false
 access-control-allow-origin = *
+# Enable verbose error logging, lending aid to dapp development
+verbose-http-errors=true
 # Print out contracts
 contracts-console = true
 # Prevent error when deploying system contracts https://git.io/fpKc8
@@ -20,6 +22,7 @@ plugin = eosio::history_api_plugin
 # Enable the mongodb plugin
 plugin = eosio::mongo_db_plugin
 mongodb-uri = mongodb://mongo:27017/EOSFN
-# Whitelist contract actions you want to store on the history database
-# mongodb-filter-on = '*'
-mongodb-filter-on = eoslocal:greet:
+# Enable mongodb to capture extra block data
+mongodb-store-transactions = true
+mongodb-store-transaction-traces = true
+mongodb-store-action-traces = true


### PR DESCRIPTION
Extra options are necessary for more generalized development. The verbose-http-errors allows allows for error assertions to be readable. The mongodb additions enable the capturing of ancillary block info necessary for capturing and using inline actions. Finally, removing the whitelist mongodb filter allows for developers to run and capture their own actions (while not excluding the capturing of the demo).

If any of these disagree with the community's vision though, feel free to disregard, but figured I'd make a PR for this since I find this to be the default setup I keep incorporating myself.

The main consideration is the removal of the whitelist. I know you have a commented out wildcard that one could simply toggle on, but it seemed like an extra unnecessary step in my mind.